### PR TITLE
(no fix) Speedup; reduce redundant playfield calculations

### DIFF
--- a/ai/MiniSimulator.cs
+++ b/ai/MiniSimulator.cs
@@ -168,10 +168,10 @@
                     }
 
                     //sort stupid stuff ouf
-
-                    if (botBase.getPlayfieldValue(p) > bestoldval)
+                    float newPlayfieldValue = botBase.getPlayfieldValue(p);
+                    if (newPlayfieldValue > bestoldval)
                     {
-                        bestoldval = botBase.getPlayfieldValue(p);
+                        bestoldval = newPlayfieldValue;
                         bestold = p;
                     }
                     if (!test)


### PR DESCRIPTION
It was calculating the playfield value twice when it could do it once.