### PR TITLE
563.1 reduce bonus on enemy card burn

### DIFF
--- a/ai/Playfield.cs
+++ b/ai/Playfield.cs
@@ -6066,7 +6066,7 @@
                         this.enemyDeckSize--;
                         if (this.enemyAnzCards >= 10)
                         {
-                            this.evaluatePenality -= 50;
+                            this.evaluatePenality = (this.enemycarddraw >= 0) ? 10 : 25;
                             //return;
                         }
                         else


### PR DESCRIPTION
AI places too much value on card burn. For reference: Control's
boardvalue calculation reduces boards by 10 points per enemy card draw.
Card burn is good, but not worth the enemy having another card.