### PR TITLE
Allow dynamic settings file based on enemy class

### DIFF
--- a/HR/Program.cs
+++ b/HR/Program.cs
@@ -195,13 +195,19 @@ namespace HREngine.Bots
 
             // reload settings
             HeroEnum heroname = Hrtprozis.Instance.heroNametoEnum(ownName);
-            if (deckChanged || heroname != Hrtprozis.Instance.heroname)
+            HeroEnum enemyHeroname = Hrtprozis.Instance.heroNametoEnum(enemName);
+            if (deckChanged || heroname != Hrtprozis.Instance.heroname || enemyHeroname != Hrtprozis.Instance.enemyHeroname)
             {
                 if (heroname != Hrtprozis.Instance.heroname)
                 {
                     Helpfunctions.Instance.ErrorLog("New Class: \"" + Hrtprozis.Instance.heroEnumtoCommonName(heroname) + "\", Old Class: \"" + Hrtprozis.Instance.heroEnumtoCommonName(Hrtprozis.Instance.heroname) + "\"");
                 }
+                if (enemyHeroname != Hrtprozis.Instance.enemyHeroname)
+                {
+                    Helpfunctions.Instance.ErrorLog("New Enemy Class: \"" + Hrtprozis.Instance.heroEnumtoCommonName(enemyHeroname) + "\", Old Class: \"" + Hrtprozis.Instance.heroEnumtoCommonName(Hrtprozis.Instance.enemyHeroname) + "\"");
+                }
                 Hrtprozis.Instance.setHeroName(ownName);
+                Hrtprozis.Instance.setEnemyHeroName(enemName);
                 ComboBreaker.Instance.updateInstance();
                 Discovery.Instance.updateInstance();
                 Mulligan.Instance.updateInstance();
@@ -211,7 +217,7 @@ namespace HREngine.Bots
 
                 //reload external process settings too
                 Helpfunctions.Instance.resetBuffer();
-                Helpfunctions.Instance.writeToBuffer(Hrtprozis.Instance.deckName + ";" + ownName + ";");
+                Helpfunctions.Instance.writeToBuffer(Hrtprozis.Instance.deckName + ";" + ownName + ";" + enemName + ";");
                 Helpfunctions.Instance.writeBufferToDeckFile();
 
             if (Mulligan.Instance.hasmulliganrules(ownName, enemName))

--- a/ai/Hrtprozis.cs
+++ b/ai/Hrtprozis.cs
@@ -191,6 +191,11 @@
             this.heroname = this.heroNametoEnum(heron);
         }
 
+        public void setEnemyHeroName(string heron)
+        {
+            this.enemyHeroname = this.heroNametoEnum(heron);
+        }
+
         public void setOwnPlayer(int player)
         {
             this.ownPlayerController = player;

--- a/ai/Settings.cs
+++ b/ai/Settings.cs
@@ -125,6 +125,7 @@ namespace HREngine.Bots
         public bool printlearnmode = true;
 
         private string ownClass = "";
+        private string enemyClass = "";
         private string deckName = "";
 
         private static readonly Settings instance = new Settings();
@@ -147,6 +148,7 @@ namespace HREngine.Bots
         public Behavior updateInstance()
         {
             ownClass = Hrtprozis.Instance.heroEnumtoCommonName(Hrtprozis.Instance.heroname);
+            enemyClass = Hrtprozis.Instance.heroEnumtoCommonName(Hrtprozis.Instance.enemyHeroname);
             deckName = Hrtprozis.Instance.deckName;
             return readSettings();
         }
@@ -181,23 +183,46 @@ namespace HREngine.Bots
             string datapath = path + "Data" + System.IO.Path.DirectorySeparatorChar;
             string classpath = datapath + ownClass + System.IO.Path.DirectorySeparatorChar;
             string deckpath = classpath + deckName + System.IO.Path.DirectorySeparatorChar;
-
+            bool dynamicBehavior = false;
 
             // if we have a deckName then we have a real ownClass too, not the default "druid"
-            if (deckName != "" && System.IO.File.Exists(deckpath + "settings.txt"))
+            if (deckName != "" && System.IO.File.Exists(deckpath + "settings-" + enemyClass + ".txt"))
+            {
+                dynamicBehavior = true;
+                path = deckpath;
+                Helpfunctions.Instance.ErrorLog("read deck " + deckName + System.IO.Path.DirectorySeparatorChar + "settings-" + enemyClass + ".txt...");
+            }
+            else if (deckName != "" && System.IO.File.Exists(deckpath + "settings.txt"))
             {
                 path = deckpath;
                 Helpfunctions.Instance.ErrorLog("read deck " + deckName + System.IO.Path.DirectorySeparatorChar + "settings.txt...");
+            }
+            else if (deckName != "" && System.IO.File.Exists(classpath + "settings-" + enemyClass + ".txt"))
+            {
+                dynamicBehavior = true;
+                path = classpath;
+                Helpfunctions.Instance.ErrorLog("read class " + ownClass + System.IO.Path.DirectorySeparatorChar + "settings-" + enemyClass + ".txt...");
             }
             else if (deckName != "" && System.IO.File.Exists(classpath + "settings.txt"))
             {
                 path = classpath;
                 Helpfunctions.Instance.ErrorLog("read class " + ownClass + System.IO.Path.DirectorySeparatorChar + "settings.txt...");
             }
+            else if (deckName != "" && System.IO.File.Exists(datapath + "settings-" + enemyClass + ".txt"))
+            {
+                dynamicBehavior = true;
+                path = datapath;
+                Helpfunctions.Instance.ErrorLog("read Data" + System.IO.Path.DirectorySeparatorChar + "settings-" + enemyClass + ".txt...");
+            }
             else if (deckName != "" && System.IO.File.Exists(datapath + "settings.txt"))
             {
                 path = datapath;
                 Helpfunctions.Instance.ErrorLog("read Data" + System.IO.Path.DirectorySeparatorChar + "settings.txt...");
+            }
+            else if (System.IO.File.Exists(path + "settings-" + enemyClass + ".txt"))
+            {
+                dynamicBehavior = true;
+                Helpfunctions.Instance.ErrorLog("read base settings-" + enemyClass + ".txt...");
             }
             else if (System.IO.File.Exists(path + "settings.txt"))
             {
@@ -209,14 +234,29 @@ namespace HREngine.Bots
                 return setDefaultSettings();
             }
 
-            try
+            if (dynamicBehavior)
             {
-                lines = System.IO.File.ReadAllLines(path + "settings.txt");
+                try
+                {
+                    lines = System.IO.File.ReadAllLines(path + "settings-" + enemyClass + ".txt");
+                }
+                catch
+                {
+                    Helpfunctions.Instance.ErrorLog("settings-" + enemyClass + ".txt read error. Continuing without user-defined rules.");
+                    return setDefaultSettings();
+                }
             }
-            catch
+            else
             {
-                Helpfunctions.Instance.ErrorLog("settings.txt read error. Continuing without user-defined rules.");
-                return setDefaultSettings();
+                try
+                {
+                    lines = System.IO.File.ReadAllLines(path + "settings.txt");
+                }
+                catch
+                {
+                    Helpfunctions.Instance.ErrorLog("settings.txt read error. Continuing without user-defined rules.");
+                    return setDefaultSettings();
+                }
             }
 
             Behavior returnbehav = new BehaviorControl();

--- a/external process/Program.cs
+++ b/external process/Program.cs
@@ -125,12 +125,15 @@ namespace HREngine.Bots
             //Helpfunctions.Instance.ErrorLog(data);
             string deckname = data.Split(';')[0];
             string ownname = data.Split(';')[1];
+            string enemyname = data.Split(';')[2];
             HeroEnum heroname = Hrtprozis.Instance.heroNametoEnum(ownname);
+            HeroEnum enemyHeroname = Hrtprozis.Instance.heroNametoEnum(enemyname);
 
-            if (Hrtprozis.Instance.deckName != deckname || heroname != Hrtprozis.Instance.heroname)
+            if (Hrtprozis.Instance.deckName != deckname || heroname != Hrtprozis.Instance.heroname || enemyHeroname != Hrtprozis.Instance.enemyHeroname)
             {
                 Hrtprozis.Instance.setDeckName(deckname);
                 Hrtprozis.Instance.setHeroName(ownname);
+                Hrtprozis.Instance.setEnemyHeroName(enemyname);
                 ComboBreaker.Instance.updateInstance();
                 Discovery.Instance.updateInstance();
                 Mulligan.Instance.updateInstance();


### PR DESCRIPTION
Example: 
settings-warrior.txt

Uses common name:
druid
hunter
mage
paladin
priest
shaman
rogue
warlock
warrior